### PR TITLE
Add Labs-stats role

### DIFF
--- a/playbooks/prep-demo.yml
+++ b/playbooks/prep-demo.yml
@@ -45,6 +45,14 @@
   - role: createjenkinsjob
   # - role: seedjenkins
 
+- name: "Record stats"
+  hosts: dbserver
+  become: yes
+  vars:
+    labs_username: "{{ demo_username }}"
+  roles:
+    - labs-stats
+
 - name: "Demo prep clean-up"
   hosts: localhost
   roles:

--- a/playbooks/roles
+++ b/playbooks/roles
@@ -1,0 +1,1 @@
+/home/trukmana/labs-demo/roles

--- a/playbooks/roles
+++ b/playbooks/roles
@@ -1,1 +1,1 @@
-/home/trukmana/labs-demo/roles
+../roles/

--- a/roles/labs-stats/README.md
+++ b/roles/labs-stats/README.md
@@ -17,3 +17,25 @@ Running the Playbook
 --------------------
 
 `$ ansible-playbook playbooks/prep-demo.yml --ask-become-pass` if become is enabled
+
+Database Schema
+---------------
+
+`labs_stats_db.GlobalStats`
+
+```
+{
+	{'name': 'runs', 'count': 5},
+	{'name': 'unique_users', 'count': 2}
+}
+```
+`labs_stats_db.UserRuns`
+
+```
+{
+	{'username': 'user1', 'count': 1},
+	{'username': 'user2', 'count': 5},
+	...
+	{'username': 'usern', 'count': 2}
+}
+```

--- a/roles/labs-stats/README.md
+++ b/roles/labs-stats/README.md
@@ -1,0 +1,19 @@
+Labs Stats
+==========
+
+This role installs mongodb on the host and updates labs demo stats after each successful run.
+
+Requirements
+------------
+
+The control machine SSH key must be on the `authorized_keys` of the DB server machine. To install mongodb, sudo access is required hence the `become: true` in `prep-demo.yml`. If mongodb is already installed you can comment out that line.
+
+Role Variables
+--------------
+
+- `labs_username`: The labs username that we want to record in the database (currently pulled from `demo_username`).
+
+Running the Playbook
+--------------------
+
+`$ ansible-playbook playbooks/prep-demo.yml --ask-become-pass` if become is enabled

--- a/roles/labs-stats/files/update_db.py
+++ b/roles/labs-stats/files/update_db.py
@@ -30,7 +30,6 @@ def update_count_per_user(username):
 
 
 command = sys.argv[1]
-print len(sys.argv)
 if len(sys.argv) < 3:
   username = None
 else:

--- a/roles/labs-stats/files/update_db.py
+++ b/roles/labs-stats/files/update_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin python
+#!/usr/bin/python
 import pymongo
 import sys
 

--- a/roles/labs-stats/files/update_db.py
+++ b/roles/labs-stats/files/update_db.py
@@ -1,0 +1,42 @@
+#!/usr/bin python
+import pymongo
+import sys
+
+def update_runs_count():
+  client = pymongo.MongoClient("mongodb://localhost:27017/labs_stats_db")
+  db = client.labs_stats_db
+
+  runs = db.GlobalStats.find({'name': 'runs'})
+  if runs.count() == 0:
+    db.GlobalStats.insert({'name': 'runs', 'count': 1})
+  else:
+    db.GlobalStats.update_one({'name': 'runs'}, {'$inc': {'count': 1}}, upsert=False)
+
+def update_count_per_user(username):
+  client = pymongo.MongoClient("mongodb://localhost:27017/labs_stats_db")
+  db = client.labs_stats_db
+
+  user_runs_count = db.UserRuns.find({'username': username})
+  unique_users_count = db.GlobalStats.find({'name': 'unique_users'})
+
+  if unique_users_count.count() == 0:
+    db.GlobalStats.insert({'name': 'unique_users', 'count': 1})
+
+  if user_runs_count.count() == 0:
+    db.UserRuns.insert({'username': username, 'count': 1})
+    db.GlobalStats.update_one({'name': 'unique_users'}, {'$inc': {'count': 1}}, upsert=False)
+  else:
+    db.UserRuns.update_one({'username': username}, {'$inc': {'count': 1}}, upsert=False)
+
+
+command = sys.argv[1]
+print len(sys.argv)
+if len(sys.argv) < 3:
+  username = None
+else:
+  username = sys.argv[2]
+
+if command == 'update_runs_count':
+  update_runs_count()
+elif command == 'update_count_per_user':
+  update_count_per_user(username)

--- a/roles/labs-stats/files/update_db.py
+++ b/roles/labs-stats/files/update_db.py
@@ -20,7 +20,7 @@ def update_count_per_user(username):
   unique_users_count = db.GlobalStats.find({'name': 'unique_users'})
 
   if unique_users_count.count() == 0:
-    db.GlobalStats.insert({'name': 'unique_users', 'count': 1})
+    db.GlobalStats.insert({'name': 'unique_users', 'count': 0})
 
   if user_runs_count.count() == 0:
     db.UserRuns.insert({'username': username, 'count': 1})

--- a/roles/labs-stats/tasks/configure_mongodb.yml
+++ b/roles/labs-stats/tasks/configure_mongodb.yml
@@ -1,0 +1,26 @@
+---
+- name: 'Check if mongodb is installed'
+  command: which mongod
+  register: mongod_check
+  ignore_errors: yes
+
+- name: 'Install mongodb if not installed'
+  include: 'install_mongodb.yml'
+  when: mongod_check != '/usr/bin/mongod'
+
+- name: 'Start MongoDB'
+  service:
+    name: mongod
+    state: started
+
+- name: 'Check if pip is installed'
+  command: which pip
+  register: pip_check
+  ignore_errors: yes
+
+- name: 'Install pip if not installed'
+  command: easy_install pip
+  when: pip_check != '/usr/bin/pip'
+
+- name: 'Install pymongo'
+  command: pip install pymongo

--- a/roles/labs-stats/tasks/install_mongodb.yml
+++ b/roles/labs-stats/tasks/install_mongodb.yml
@@ -1,0 +1,10 @@
+---
+- name: 'Copy mongodb repo'
+  copy:
+    src: ../templates/mongodb-org-3.4.repo
+    dest: /etc/yum.repos.d/mongodb-org-3.4.repo
+
+- name: 'Install mongodb-org'
+  package:
+    name: mongodb-org
+    state: latest

--- a/roles/labs-stats/tasks/install_mongodb.yml
+++ b/roles/labs-stats/tasks/install_mongodb.yml
@@ -1,8 +1,15 @@
 ---
-- name: 'Copy mongodb repo'
-  copy:
-    src: ../templates/mongodb-org-3.4.repo
-    dest: /etc/yum.repos.d/mongodb-org-3.4.repo
+- name: 'Add mongodb repo 3.0 and up'
+  template:
+    src: mongodb-org-3.0-and-above.j2
+    dest: "/etc/yum.repos.d/mongodb-org-{{ mongodb_ver }}.repo"
+  when: mongodb_ver|float() >= 3.0
+
+- name: 'Add mongodb repo before 3.0'
+  template:
+    src: mongodb-org-below-3.0.j2
+    dest: "/etc/yum.repos.d/mongodb-org-{{mongodb_ver}}.repo"
+  when: mongodb_ver|float() < 3.0
 
 - name: 'Install mongodb-org'
   package:

--- a/roles/labs-stats/tasks/main.yml
+++ b/roles/labs-stats/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: 'Install mongodb'
+  include: configure_mongodb.yml
+
+- name: 'Update demo runs count'
+  command: "./update_db.py update_runs_count"
+  args:
+    chdir: '{{ role_path }}/files'
+
+- name: 'Update number of runs per user'
+  command: "./update_db.py update_count_per_user {{ labs_username }}"
+  args:
+    chdir: '{{ role_path }}/files'

--- a/roles/labs-stats/templates/mongodb-org-3.0-and-above.j2
+++ b/roles/labs-stats/templates/mongodb-org-3.0-and-above.j2
@@ -1,0 +1,6 @@
+[mongodb-org-{{ mongodb_ver }}]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/{{ os_family }}/{{ os_ver }}/mongodb-org/{{ mongodb_ver }}/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-{{ mongodb_ver }}.asc

--- a/roles/labs-stats/templates/mongodb-org-3.4.repo
+++ b/roles/labs-stats/templates/mongodb-org-3.4.repo
@@ -1,0 +1,6 @@
+[mongodb-org-3.4]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.4/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc

--- a/roles/labs-stats/templates/mongodb-org-3.4.repo
+++ b/roles/labs-stats/templates/mongodb-org-3.4.repo
@@ -1,6 +1,0 @@
-[mongodb-org-3.4]
-name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/7/mongodb-org/3.4/x86_64/
-gpgcheck=1
-enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-3.4.asc

--- a/roles/labs-stats/templates/mongodb-org-below-3.0.j2
+++ b/roles/labs-stats/templates/mongodb-org-below-3.0.j2
@@ -1,0 +1,5 @@
+[mongodb-org-{{ mongodb_ver }}]
+name=MongoDB {{ mongodb_ver }} Repository
+baseurl=http://downloads-distro.mongodb.org/repo/{{ os_family }}/os/x86_64/
+gpgcheck=0
+enabled=1

--- a/roles/labs-stats/tests/README.md
+++ b/roles/labs-stats/tests/README.md
@@ -1,0 +1,12 @@
+#UPDATE DATABASE ON LABS DEMO RUNS
+
+An ansible role that updates the database after each demo run to log statistics. If MongoDB is not installed on `dbserver` host, this role will also attempt to install it.
+
+---
+##Testing
+
+run the test ```ansible-playbook -i inventory test_labs_stats.yml --ask-become-pass```
+
+###Test Notes: 
+
+* This requires that you have sudo privillege to install MongoDB on the host. If installation not needed simply comment out `become: yes` on the playbook

--- a/roles/labs-stats/tests/roles
+++ b/roles/labs-stats/tests/roles
@@ -1,0 +1,1 @@
+/home/trukmana/labs-demo/roles

--- a/roles/labs-stats/tests/roles
+++ b/roles/labs-stats/tests/roles
@@ -1,1 +1,1 @@
-/home/trukmana/labs-demo/roles
+../../../roles/

--- a/roles/labs-stats/tests/test_labs_stats.yml
+++ b/roles/labs-stats/tests/test_labs_stats.yml
@@ -1,0 +1,11 @@
+---
+# This test covers the full feature set provided by the role
+
+- name: Update Labs Stats
+  hosts: dbserver
+  become: yes
+  vars:
+    labs_username: testuser
+
+  roles: 
+    - labs-stats

--- a/roles/labs-stats/tests/test_labs_stats.yml
+++ b/roles/labs-stats/tests/test_labs_stats.yml
@@ -6,6 +6,9 @@
   become: yes
   vars:
     labs_username: testuser
+    mongodb_ver: 2.6
+    os_family: redhat
+    os_ver: 7
 
   roles: 
     - labs-stats


### PR DESCRIPTION
As discussed on Trello this role is to record demo runs onto a database (MongoDB). This role also includes the installation of MongoDB. I have tested this role on a Fedora 25 VM on my machine.

- [x] Select OS family and version  
- [x] Select mongodb version  

README is located at `roles/labs-stats/README.md`